### PR TITLE
list_picturesのエラー改善

### DIFF
--- a/ncc/preprocessing/get_dataset.py
+++ b/ncc/preprocessing/get_dataset.py
@@ -1,7 +1,7 @@
 import numpy as np
 import glob
 
-from keras.preprocessing.image import array_to_img, img_to_array, list_pictures, load_img
+from keras_preprocessing.image import array_to_img, img_to_array, list_pictures, load_img
 
 
 def get_dataset(target_dir):


### PR DESCRIPTION
# どんなもの？
get_dataset.py実行時のlist_pictureメソッドのimportエラーを改善

# 備考
kerasのバージョン2.1.6以降ではkeras.preprocessing.imageからlist_pictureメソッドが削除されているため、keras_preprocessingに変更