### PR TITLE
WIP:video read on another thread

### DIFF
--- a/ncc/video/VideoProcess.py
+++ b/ncc/video/VideoProcess.py
@@ -4,7 +4,6 @@ import os
 import sys
 import cv2
 from threading import Thread
-from timeit import default_timer as timer
 
 
 class VideoProcess:


### PR DESCRIPTION
#  Video Read の別スレッド化

## これは何？
- video.readを別スレッドにして、frameの取得を待たなくて良いクラスを作った。
- mp4 => avi (こちらの方が、保存中に確認できる。)

## どうして作った？
動画処理の高速化

## 注意する点がある場合は？
他の重たい処理を組み合わせる時も、別スレッドにする
その際のフレームの取得は
`VideoProcess.frame`

## これを改良する余地がある場合は？
任意の重たい処理の関数も引数にすること。